### PR TITLE
init.vim: remove roxma/LanguageServer-php-neovim, no longer necessary

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -65,8 +65,6 @@ Plug 'autozimu/LanguageClient-neovim', { 'do': ':UpdateRemotePlugins' }
 Plug 'junegunn/fzf'
 Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
 
-Plug 'roxma/LanguageServer-php-neovim', {'do': 'composer install && composer run-script parse-stubs'} "(neovim-only)
-
 "Extract vimballs from www.vim.org
 Plug 'vim-scripts/Vimball'
 


### PR DESCRIPTION
with autozimu/LanguageClient-neovim + Shougo/deoplete.nvim